### PR TITLE
Update IA IIIF endpoint

### DIFF
--- a/src/templates/document.js
+++ b/src/templates/document.js
@@ -114,7 +114,7 @@ const Document = ({ data }) => {
     </li>
   ))
 
-  const manifestUrl = `https://iiif.archivelab.org/iiif/${doc.iaId}/manifest.json`
+  const manifestUrl = `https://iiif.archive.org/iiif/${doc.iaId}/manifest.json`
 
   let canvasIndex = 0
   if (typeof window !== "undefined" && window.location.hash) {


### PR DESCRIPTION
I happened to notice that the IIIF document viewer is no longer working. For example, notice the empty display when you visit https://www.unlockingtheairwaves.org/document/naeb-b093-f05/ ?

![Screenshot 2024-03-04 at 9 38 06 PM](https://github.com/umd-mith/airwaves/assets/33829/385134cd-f2c6-41e6-a3b3-0dd482a9edf8)

I inquired over at the Internet Archive's IIIF repository and learned that they are now deprecating the old iiif.archivelab.org url in favor of using iiif.archive.org.

https://github.com/internetarchive/iiif/issues/61

If you make the small change to the IIIF URL in this pull request it should start working again. Here is the same page running locally after correcting the URL:

![Screenshot 2024-03-04 at 9 37 03 PM](https://github.com/umd-mith/airwaves/assets/33829/322a7dae-3bfa-4c43-bda3-be832df160a5)